### PR TITLE
altered the positioning of child page navigation to end of page

### DIFF
--- a/cms/pages/templates/pages/base_page.html
+++ b/cms/pages/templates/pages/base_page.html
@@ -15,13 +15,13 @@
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
             {{ self.body }}
-            <div class="nhsuk-review-date">
+            {% comment %} <div class="nhsuk-review-date">
                 <p class="nhsuk-body-s">
                     Page first published: {{ self.first_published_at|date:'d F Y' }}<br>
                     Last updated: {{ self.last_published_at|date:'d F Y' }}
                 </p>
-            </div>
-            <ul class="nhsuk-list nhsuk-pagination__list">
+            </div> {% endcomment %}
+            {% comment %} <ul class="nhsuk-list nhsuk-pagination__list">
                 {% if self.prev_sibling %}
                 <li class="nhsuk-pagination-item--previous">
                     <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{ self.prev_sibling.url }}">
@@ -52,10 +52,11 @@
                     </a>
                 </li>
                 {% endif %}
-            </ul>
+            </ul> {% endcomment %}
         </div>
         <div class="nhsuk-grid-column-one-third">
             {% if children %}
+            <h2>In this section</h2>
             <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
                 <h2 class="nhsuk-u-visually-hidden">Contents</h2>
                 <ol class="nhsuk-contents-list__list">

--- a/cms/pages/templates/pages/components_page.html
+++ b/cms/pages/templates/pages/components_page.html
@@ -7,32 +7,20 @@
 
 <div class="nhsuk-width-container">
     <h1>{{ self.title }}</h1>
-    {% if children %}
-    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
-        <h2 class="nhsuk-u-visually-hidden">Contents</h2>
-        <ol class="nhsuk-contents-list__list">
-            {% for child in children %}
-            <li class="nhsuk-contents-list__item">
-                <a class="nhsuk-contents-list__link" href="{{ child.url }}">{{ child }}</a>
-            </li>
-            {% endfor %}
-
-        </ol>
-    </nav>
-    {% endif %}
+    
 
     {% for block in self.body %}
         {% include_block block %}
     {% endfor %}
 
-    <div class="nhsuk-review-date">
+    {% comment %} <div class="nhsuk-review-date">
         <p class="nhsuk-body-s">
             Page first published: {{ self.first_published_at|date:'d F Y' }}<br>
             Last updated: {{ self.last_published_at|date:'d F Y' }}
         </p>
-    </div>
+    </div> {% endcomment %}
 
-    <ul class="nhsuk-list nhsuk-pagination__list">
+    {% comment %} <ul class="nhsuk-list nhsuk-pagination__list">
         {% if self.prev_sibling %}
         <li class="nhsuk-pagination-item--previous">
             <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{ self.prev_sibling.url }}">
@@ -65,7 +53,22 @@
         </li>
         {% endif %}
 
-    </ul>
+    </ul> {% endcomment %}
+
+    {% if children %}
+    <h2>In this section</h2>
+    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
+        <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+        <ol class="nhsuk-contents-list__list">
+            {% for child in children %}
+            <li class="nhsuk-contents-list__item">
+                <a class="nhsuk-contents-list__link" href="{{ child.url }}">{{ child }}</a>
+            </li>
+            {% endfor %}
+
+        </ol>
+    </nav>
+    {% endif %}
 
 </div>
 

--- a/cms/search/views.py
+++ b/cms/search/views.py
@@ -39,8 +39,8 @@ def search(request):
 
     search_type = ''
     search_results_count = None
-    date_from = request.GET.get('date_from')
-    date_to = request.GET.get('date_to')
+    date_from = request.GET.get('date_from', '')
+    date_to = request.GET.get('date_to', '')
 
     # Search
     if query:

--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -7010,6 +7010,25 @@ nav a {
     .nhsuk-list .nhsuk-panel.nhsei-panel-search-result {
       padding: 24px; } }
 
+.block-panel .nhsuk-panel {
+  margin: 0;
+  padding: 0;
+  background-color: transparent; }
+
+.nhsuk-promo {
+  margin-top: 20px; }
+  .nhsuk-promo .nhsuk-promo__link-wrapper {
+    background-color: #005eb8;
+    color: #ffffff; }
+    .nhsuk-promo .nhsuk-promo__link-wrapper h3 {
+      text-decoration: none; }
+    .nhsuk-promo .nhsuk-promo__link-wrapper p {
+      color: #ffffff; }
+    .nhsuk-promo .nhsuk-promo__link-wrapper:hover {
+      background-color: #004b93; }
+      .nhsuk-promo .nhsuk-promo__link-wrapper:hover h3 {
+        color: #ffffff; }
+
 .nhsuk-image {
   width: 100%; }
 

--- a/packages/custom-styles/_wagtail_frontend_temporary_over_rides.scss
+++ b/packages/custom-styles/_wagtail_frontend_temporary_over_rides.scss
@@ -1,0 +1,27 @@
+.block-panel {
+    .nhsuk-panel {
+        margin: 0;
+        padding: 0;
+        background-color: transparent;
+    }
+}
+
+.nhsuk-promo {
+    margin-top: 20px;
+    .nhsuk-promo__link-wrapper {
+        background-color: $color_nhsuk-blue;
+        color: $color_nhsuk-white;
+        h3 {
+            text-decoration: none;
+        }
+        p {
+            color: $color_nhsuk-white
+        }
+        &:hover {
+            background-color: $color_shade_nhsuk-blue-20;
+            h3 {
+                color: $color_nhsuk-white;
+            }
+        }
+    }
+}

--- a/packages/nhsuk.scss
+++ b/packages/nhsuk.scss
@@ -47,6 +47,7 @@
 @import 'custom-styles/alert';
 @import 'custom-styles/home_page';
 @import 'custom-styles/search-results';
+@import 'custom-styles/wagtail_frontend_temporary_over_rides';
 
 
 @import 'custom-styles/base';


### PR DESCRIPTION
altered the positioning of child page navigation to end of page

added some temporary style overrides to get around the wagtailfrontend widgets having a background of white, this seemed 
the best way to go for now as soon the widgets will need to be remade to suit our use case

there was also a search error I noticed where ordering the results passed in invalid date format, now fixed