### PR TITLE
Fix/575 temporary megamenu with hardcoded links

### DIFF
--- a/cms/templates/partials/nav-links/improvement.html
+++ b/cms/templates/partials/nav-links/improvement.html
@@ -1,0 +1,77 @@
+<li>
+  <a href="/improvement"
+  class="menu-link mega-menu-link mega-menu-header">
+  Improvement
+  </a>
+</li>
+<li>
+  <a href="/improvement-hub/"
+  class="menu-link mega-menu-link">
+  Improvement hub
+  </a>
+</li>
+<li>
+  <a href="/patient-safety/"
+  class="menu-link mega-menu-link">
+  Patient safety
+  </a>
+</li>
+<li>
+  <a href="/safeguarding/"
+  class="menu-link mega-menu-link">
+  Safeguarding
+  </a>
+</li>
+<li>
+  <a href="/insights-platform/"
+  class="menu-link mega-menu-link">
+  Insights platform
+  </a>
+</li>
+<li>
+  <a href="/always-events/"
+  class="menu-link mega-menu-link">
+  Always events
+  </a>
+</li>
+<li>
+  <a href="/evidence-based-interventions/"
+  class="menu-link mega-menu-link">
+  Evidence-Based Interventions Programme
+  </a>
+</li>
+<li>
+  <a href="/ltphimenu/"
+  class="menu-link mega-menu-link">
+  Menu of evidence-based interventions and approaches for addressing and reducing health inequalities
+  </a>
+</li>
+<li>
+  <a href="/seven-day-hospital-services/"
+  class="menu-link mega-menu-link">
+  7 day hospital services
+  </a>
+</li>
+<li>
+  <a href="/winter/"
+  class="menu-link mega-menu-link">
+  Winter resilience
+  </a>
+</li>
+<li>
+  <a href="/aac/"
+  class="menu-link mega-menu-link">
+  NHS Accelerated Access Collaborative (AAC)
+  </a>
+</li>
+<li>
+  <a href="/greenernhs/"
+  class="menu-link mega-menu-link">
+  A greener NHS
+  </a>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/news-blogs.html
+++ b/cms/templates/partials/nav-links/news-blogs.html
@@ -1,0 +1,22 @@
+<li>
+    <a href="/news/nhs-england-improvement/"
+    class="menu-link mega-menu-link">
+      News
+    </a>
+</li>
+<li>
+    <a href="/blogs/blog/"
+    class="menu-link mega-menu-link">
+      Blogs
+    </a>
+</li>
+<li>
+    <a href="/events/"
+    class="menu-link mega-menu-link">
+      Events
+    </a>
+</li>
+
+<li class="mobile-menu-back-item">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/our-people.html
+++ b/cms/templates/partials/nav-links/our-people.html
@@ -1,0 +1,38 @@
+<li>
+  <a href="/our-people"
+  class="menu-link mega-menu-link mega-menu-header">
+    Our people
+  </a>
+</li>
+<li>
+  <a href="/ournhspeople/"
+  class="menu-link mega-menu-link">
+    NHS People Plan
+  </a>
+</li>
+<li>
+  <a href="/looking-after-our-people/"
+  class="menu-link mega-menu-link">
+    Looking after our people
+  </a>
+</li>
+<li>
+  <a href="/pensions/"
+  class="menu-link mega-menu-link">
+    Pensions
+  </a>
+</li>
+<li>
+  <a href="javascript:void(0);"
+  class="menu-link mega-menu-link" aria-haspopup="true">
+  Celebrating NHS
+  </a>
+  <ul class="menu menu-list menu-multiColumn">
+    {% include "partials/nav-links/our-people__celebrating-nhs.html" %}
+  </ul>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+  <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/our-people__celebrating-nhs.html
+++ b/cms/templates/partials/nav-links/our-people__celebrating-nhs.html
@@ -1,0 +1,23 @@
+<li>
+  <a href="/nhsbirthday/"
+  class="menu-link mega-menu-link">
+    NHS birthday 2020
+  </a>
+</li>
+<li>
+  <a href="/atnhs"
+  class="menu-link mega-menu-link">
+    @ NHS
+  </a>
+</li>
+<li>
+  <a href="/nhs-parliamentary-awards"
+  class="menu-link mega-menu-link">
+  "NHS Parliamentary awards"
+  </a>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/our-work__commissioning.html
+++ b/cms/templates/partials/nav-links/our-work__commissioning.html
@@ -1,0 +1,1 @@
+<!-- For now it is decided that no list items show under commissioning -->

--- a/cms/templates/partials/nav-links/our-work__our-priorities.html
+++ b/cms/templates/partials/nav-links/our-work__our-priorities.html
@@ -1,0 +1,75 @@
+<li>
+    <a href="/cancer/" class="menu-link mega-menu-link">
+      Cancer
+    </a>
+</li>
+<li>
+    <a href="/coronavirus/"
+    class="menu-link mega-menu-link">
+    Coronavirus
+    </a>
+</li>
+<li>
+    <a href="/diabetes/"
+    class="menu-link mega-menu-link">
+    Diabetes
+    </a>
+</li>
+<li>
+    <a href="/fft/"
+    class="menu-link mega-menu-link">
+    Friends and family test
+    </a>
+</li>
+<li>
+    <a href="/genomics/"
+    class="menu-link mega-menu-link">
+       Genomics
+    </a>
+</li>
+<li>
+    <a href="/hssf/"
+    class="menu-link mega-menu-link">
+    Health Systems Support framework
+    </a>
+</li>
+<li>
+    <a href="/learning-disabilities/"
+    class="menu-link mega-menu-link">
+    Learning disabilities
+    </a>
+</li>
+<li>
+    <a href="/mental-health/"
+    class="menu-link mega-menu-link">
+    Mental health
+    </a>
+</li>
+<li>
+    <a href="/medicines-2/"
+    class="menu-link mega-menu-link">
+    Medicines: improving outcomes and value
+    </a>
+</li>
+<li>
+    <a href="/rightcare/"
+    class="menu-link mega-menu-link">
+    Right Care
+    </a>
+</li>
+<li>
+    <a href="/shared-decision-making/"
+    class="menu-link mega-menu-link">
+    Shared decision making
+    </a>
+</li>
+<li>
+    <a href="/urgent-emergency-care/"
+    class="menu-link mega-menu-link">
+    Urgent and emergency care
+    </a>
+</li>
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/our-work__ways-of-working.html
+++ b/cms/templates/partials/nav-links/our-work__ways-of-working.html
@@ -1,0 +1,107 @@
+<li>
+    <a href="/long-term-plan/"
+    class="menu-link mega-menu-link">
+      Long term plan
+    </a>
+</li>
+<li>
+    <a href="new-care-models/"
+    class="menu-link mega-menu-link">
+      New care models
+    </a>
+</li>
+<li>
+    <a href="/healthcare-science/"
+    class="menu-link mega-menu-link">
+      Healthcare science
+    </a>
+</li>
+<li>
+    <a href="/integrated-care-pioneers/"
+    class="menu-link mega-menu-link">
+      Integrated care pioneers
+    </a>
+</li>
+<li>
+    <a href="/personalised-health-and-care-framework/"
+    class="menu-link mega-menu-link">
+      Personalised health and care framework
+    </a>
+</li>
+<li>
+    <a href="/digitaltechnology/"
+    class="menu-link mega-menu-link">
+      Digital transformation
+    </a>
+</li>
+<li>
+    <a href="/elective-care-transformation/"
+    class="menu-link mega-menu-link">
+      Elective care transformation
+    </a>
+</li>
+<li>
+    <a href="/integratedcare/"
+    class="menu-link mega-menu-link">
+      Integrated care
+    </a>
+</li>
+<li>
+    <a href="/primary-care/"
+    class="menu-link mega-menu-link">
+      Primary care
+    </a>
+</li>
+<li>
+    <a href="/gp/"
+    class="menu-link mega-menu-link">
+      General Practice
+    </a>
+</li>
+<li>
+    <a href="/gp-online-services/"
+    class="menu-link mega-menu-link">
+      GP online services
+    </a>
+</li>
+<li>
+    <a href="/nursingmidwifery/"
+    class="menu-link mega-menu-link">
+      Nursing and midwifery
+    </a>
+</li>
+<li>
+    <a href="/medical-revalidation/"
+    class="menu-link mega-menu-link">
+      Medical revalidation
+    </a>
+</li>
+<li>
+    <a href="/ahp/"
+    class="menu-link mega-menu-link">
+      Allied Health professions
+    </a>
+</li>
+<li>
+    <a href="/mat-transformation/"
+    class="menu-link mega-menu-link">
+      Maternity transformation programme
+    </a>
+</li>
+<li>
+    <a href="/cno-summit/"
+    class="menu-link mega-menu-link">
+      Chief Nursing Officer for England's Summit
+    </a>
+</li>
+<li>
+    <a href="/year-of-the-nurse-and-midwife-2020/"
+    class="menu-link mega-menu-link">
+      International Year of the Nurse and Midwife 2020
+    </a>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/patient-involvement.html
+++ b/cms/templates/partials/nav-links/patient-involvement.html
@@ -1,0 +1,65 @@
+<li>
+    <a href="/participation/"
+    class="menu-link mega-menu-link mega-menu-header">
+      Patient involvement
+    </a>
+</li>
+<li>
+    <a href="/participation/about/"
+    class="menu-link mega-menu-link">
+      About the involvement hub
+    </a>
+</li>
+<li>
+    <a href="/participation/get-involved/"
+    class="menu-link mega-menu-link">
+      How to get involved
+    </a>
+</li>
+<li>
+    <a href="/participation/why/"
+    class="menu-link mega-menu-link">
+      Why get involved
+    </a>
+</li>
+<li>
+    <a href="/participation/get-involved/opportunities/"
+    class="menu-link mega-menu-link">
+      Current opportunities
+    </a>
+</li>
+<li>
+    <a href="/participation/learning/"
+    class="menu-link mega-menu-link">
+      Learning and development
+    </a>
+</li>
+<li>
+    <a href="https://www.engage.england.nhs.uk/" target="_blank"
+    class="menu-link mega-menu-link">
+      Surveys and consultations
+    </a>
+</li>
+<li>
+    <a href="/participation/success/"
+    class="menu-link mega-menu-link">
+      Good practice and case studies
+    </a>
+</li>
+<li>
+    <a href="/participation/resources/bitesizeparticipation/"
+    class="menu-link mega-menu-link">
+      Resources and bite sized guides
+    </a>
+</li>
+<li>
+    <a href="/participation/involvementguidance/"
+    class="menu-link mega-menu-link">
+      Information for commissioners
+    </a>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/nav-links/publications.html
+++ b/cms/templates/partials/nav-links/publications.html
@@ -1,0 +1,30 @@
+<li>
+    <a href="/publication/nhs-england-improvement/" class="menu-link mega-menu-link">
+      NHS England & Improvement
+    </a>
+</li>
+<li>
+    <a href="/publication/corovavirus/">
+      Coronavavirus
+    </a>
+</li>
+<li>
+    <a href="/publication/commissioning/">
+      Commissioning
+    </a>
+</li>
+<li>
+    <a href="/publication/greener-nhs/">
+      Greener NHS
+    </a>
+</li>
+<li>
+    <a href="/publication/accelerated-access-collaborative/">
+      Accelerated Access Collaborative
+    </a>
+</li>
+<li>
+    <a href="/publication/improvement-hub/">
+      Improvement Hub
+    </a>
+</li>

--- a/cms/templates/partials/nav-links/publications.html
+++ b/cms/templates/partials/nav-links/publications.html
@@ -4,27 +4,36 @@
     </a>
 </li>
 <li>
-    <a href="/publication/corovavirus/">
+    <a href="/publication/corovavirus/"
+    class="menu-link mega-menu-link">
       Coronavavirus
     </a>
 </li>
 <li>
-    <a href="/publication/commissioning/">
+    <a href="/publication/commissioning/"
+    class="menu-link mega-menu-link">
       Commissioning
     </a>
 </li>
 <li>
-    <a href="/publication/greener-nhs/">
+    <a href="/publication/greener-nhs/"
+    class="menu-link mega-menu-link">
       Greener NHS
     </a>
 </li>
 <li>
-    <a href="/publication/accelerated-access-collaborative/">
+    <a href="/publication/accelerated-access-collaborative/"
+    class="menu-link mega-menu-link">
       Accelerated Access Collaborative
     </a>
 </li>
 <li>
-    <a href="/publication/improvement-hub/">
+    <a href="/publication/improvement-hub/"
+    class="menu-link mega-menu-link">
       Improvement Hub
     </a>
+</li>
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
 </li>

--- a/cms/templates/partials/navigation.html
+++ b/cms/templates/partials/navigation.html
@@ -8,8 +8,12 @@ CODEPEN: https://codepen.io/vixxofsweden/pen/xxGGYOE
           <a href="javascript:void(0);" class="mobile-menu-trigger">Open mobile menu</a>
           <ul class="menu menu-bar" aria-hidden="false" role="menubar">
               <li>
-                  <a href="/publication" class="menu-link menu-bar-link">
+                  <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">
                     Publications</a>
+                  <ul class="mega-menu mega-menu--multiLevel">
+                    <!-- Include the list partial -->
+                    {% include "partials/nav-links/publications.html" %}
+                  </ul>
               </li>
 
               <li>

--- a/cms/templates/partials/navigation.html
+++ b/cms/templates/partials/navigation.html
@@ -3,56 +3,48 @@ CODEPEN: https://codepen.io/vixxofsweden/pen/xxGGYOE
 -->
 <!-- needs refining and styling & Fix mobile-->
 <div class="nhsuk-width-container">
-  <div class="nav">
-      <nav id="header-navigation" class="" role="navigation" aria-label="Primary navigation" aria-labbeledby="label-navigation">
+  <div class="nav mega_nav_wrapper">
+      <nav id="header-navigation" class="mega_nav" role="navigation" aria-label="Primary navigation" aria-labbeledby="label-navigation">
           <a href="javascript:void(0);" class="mobile-menu-trigger">Open mobile menu</a>
           <ul class="menu menu-bar" aria-hidden="false" role="menubar">
               <li>
                   <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">
-                    Publications</a>
+                    Publications
+                  </a>
                   <ul class="mega-menu mega-menu--multiLevel">
-                    <!-- Include the list partial -->
                     {% include "partials/nav-links/publications.html" %}
                   </ul>
               </li>
 
               <li>
-                  <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">Our work</a>
+                  <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">
+                    Our work
+                  </a>
                   <ul class="mega-menu mega-menu--multiLevel">
                     <li>
-                        <a href="/ourwork" class="menu-link mega-menu-link mega-menu-header">Our work</a>
+                        <a href="/ourwork" class="menu-link mega-menu-link mega-menu-header">
+                          Our work
+                        </a>
                     </li>
                     <li>
-                        <a href="javascript:void(0);" class="menu-link mega-menu-link " aria-haspopup="true">Our priorities</a>
+                        <a href="javascript:void(0);" class="menu-link mega-menu-link " aria-haspopup="true">
+                          Our priorities
+                        </a>
                         <ul class="menu menu-list menu-multiColumn">
-                          <li>
-                              <a href="/our-priorities" class="menu-link mega-menu-link mega-menu-header">Our priorities</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          {% comment %} {% for item in data.our_priorities %}
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  {{ item['title'] }}<br />
-                                  <small>{{ item['description'] }}</small>
-                              </a>
-                            </li>
-                          {% endfor %} {% endcomment %}
-
+                          {% include "partials/nav-links/our-work__our-priorities.html" %}
                         </ul>
                     </li>
                     <li>
-                        <a href="/ways-of-working" class="menu-link mega-menu-link">Ways of working</a>
+                        <a href="javascript:void(0);" class="menu-link mega-menu-link" aria-haspopup="true">
+                          Ways of working
+                        </a>
+                        <ul class="menu menu-list menu-multiColumn">
+                          {% include "partials/nav-links/our-work__ways-of-working.html" %}
+                        </ul>
                     </li>
                     <li>
-                        <a href="/primary-secondary-care" class="menu-link mega-menu-link">Primary and secondary care
+                        <a href="/commissioning/" class="menu-link mega-menu-link">
+                          Commissioning
                         </a>
                     </li>
                     <li class="mobile-menu-back-item"><!-- Mobile back -->
@@ -62,208 +54,34 @@ CODEPEN: https://codepen.io/vixxofsweden/pen/xxGGYOE
               </li>
               <li>
                 <a href="javascript:void(0);"
-                class="menu-link menu-bar-link" aria-haspopup="true">Our people</a>
+                class="menu-link menu-bar-link" aria-haspopup="true">
+                  Our people
+                </a>
                 <ul class="mega-menu mega-menu--multiLevel">
-                  <li>
-                      <a href="/our-people" class="menu-link mega-menu-link mega-menu-header">Our people</a>
-                  </li>
-                  <li>
-                    <a href="javascript:void(0);" class="menu-link mega-menu-link" aria-haspopup="true">NHS: People Plan
-                    </a>
-                    <ul class="menu menu-list">
-                    <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                      {% comment %} {% for item in data.nhs_people_plan %}
-                      <li><!-- Link 2.1.1 -->
-                        <a href="#" class="menu-link menu-list-link">
-                            {{ item['title'] }}<br />
-                            <small>{{ item['description'] }}</small>
-                        </a>
-                      </li>
-                      {% endfor %} {% endcomment %}
-                    </ul>
-                  </li>
-                  <li>
-                    <a href="#" class="menu-link mega-menu-link">Looking after our people
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" class="menu-link mega-menu-link">Health and Care Innovation Expo
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" class="menu-link mega-menu-link">Pensions
-                    </a>
-                  </li>
+                  {% include "partials/nav-links/our-people.html" %}
                 </ul>
               </li>
               <li>
-                <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">Improvement</a>
+                <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">
+                  Improvement
+                </a>
                 <ul class="mega-menu mega-menu--multiLevel">
-                  <li>
-                    <a href="/improvement" class="menu-link mega-menu-link mega-menu-header">Improvement
-                    </a>
-                  </li>
-                  <li>
-                      <a href="javascript:void(0);" class="menu-link mega-menu-link" aria-haspopup="true">Improvement hub
-                      </a>
-                      <ul class="menu menu-list">
-                      <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                        {% comment %} {% for item in data.improvement_hub %}
-                        <li>
-                          <a href="#" class="menu-link menu-list-link">
-                              {{ item['title'] }}<br />
-                              <small>{{ item['description'] }}</small>
-                          </a>
-                        </li>
-                        {% endfor %} {% endcomment %}
-                      </ul>
-                  </li>
-                  <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                          <li>
-                            <a href="#" class="menu-link menu-list-link">A sample link</a>
-                          </li>
-                  {% comment %} {% for item in data.improvement %}
-                    <li>
-                      <a href="javascript:void(0);" class="menu-link mega-menu-link">{{ item['title'] }}</a>
-                    </li>
-                  {% endfor %} {% endcomment %}
+                  {% include "partials/nav-links/improvement.html" %}
                 </ul>
               </li>
               <li>
-                  <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">Commissioning</a>
-                  <ul class="mega-menu mega-menu--multiLevel">
-                    <li>
-                        <a href="/commissioning" class="menu-link mega-menu-link mega-menu-header">Comissioning
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Commissioned services
-                        </a>
-                    </li>
-                    <li>
-                        <a href="javascript:void(0);" class="menu-link mega-menu-link" aria-haspopup="true">About NHS commissioning
-                        </a>
-                        <ul class="menu menu-list">
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  What is commissioning?<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  Who commissions NHS services?<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Commissioned services
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Specialised commissioning
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Supporting commissioners
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Commissioning regulation
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="menu-link mega-menu-link">Commissioning policies
-                        </a>
-                    </li>
-                    <li class="mobile-menu-back-item">
-                        <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
-                    </li>
-                  </ul>
+                <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">
+                  Patient involvement
+                </a>
+                <ul class="mega-menu mega-menu--multiLevel">
+                  {% include "partials/nav-links/patient-involvement.html" %}
+                </ul>
               </li>
 
               <li>
                   <a href="javascript:void(0);" class="menu-link menu-bar-link" aria-haspopup="true">News and blogs</a>
                   <ul class="mega-menu mega-menu--multiLevel">
-                    <li>
-                        <a href="/news" class="menu-link mega-menu-link" aria-haspopup="true">News</a>
-                        <ul class="menu menu-list">
-                            <li>
-                              <a href="/news" class="menu-link menu-list-link">
-                                  News<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  Alerts<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a href="/blogs" class="menu-link mega-menu-link" aria-haspopup="true">Blogs
-                        </a>
-                        <ul class="menu menu-list">
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  Latest posts section here<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  All posts<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a href="https://www.england.nhs.uk/events/" class="menu-link mega-menu-link" aria-haspopup="true">Events
-                        </a>
-                        <ul class="menu menu-list">
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  Latest events section here<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                            <li>
-                              <a href="#" class="menu-link menu-list-link">
-                                  All events<br />
-                                  <small>Short decription of link</small>
-                              </a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="mobile-menu-back-item">
-                        <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
-                    </li>
+                    {% include "partials/nav-links/news-blogs.html" %}
                   </ul>
               </li>
 


### PR DESCRIPTION
Trello card: https://trello.com/c/RMPDqmMz 

This is a list of hardcoded links to include in the top navigation
the working spreadsheet list to map the links and the [url are here ](https://docs.google.com/spreadsheets/d/1MV08IllF4jixN4KxD6RQUIqmpgyZpvlo9LCYjWwiNJg/edit?usp=sharing)

Todo: there is a styling snag for the third level child. This can be fix in a new pull request.

### New top nav links

![Screenshot 2020-12-02 at 10 10 26](https://user-images.githubusercontent.com/2632224/100860803-e4937e00-3488-11eb-86e3-d72628c82108.png)

### Dropdown 

![Screenshot 2020-12-02 at 10 10 36](https://user-images.githubusercontent.com/2632224/100860810-e6f5d800-3488-11eb-8bbd-24fd480b2936.png)

### Snag for the child to fix next
![Screenshot 2020-12-02 at 10 10 47](https://user-images.githubusercontent.com/2632224/100860812-e78e6e80-3488-11eb-9170-5483bd7f45b7.png)

