### PR TITLE
Feature/628 add finance section to our work nav

### DIFF
--- a/cms/templates/partials/nav-links/our-work__finance.html
+++ b/cms/templates/partials/nav-links/our-work__finance.html
@@ -22,6 +22,24 @@
       NHS providers: financial accounting and reporting
     </a>
 </li>
+<li>
+    <a href="/data-services"
+    class="menu-link mega-menu-link">
+      Data Services
+    </a>
+</li>
+<li>
+    <a href="/ig"
+    class="menu-link mega-menu-link">
+      Information governance
+    </a>
+</li>
+<li>
+    <a href="/tis"
+    class="menu-link mega-menu-link">
+      The information standard
+    </a>
+</li>
 
 <li class="mobile-menu-back-item"
 class="menu-link mega-menu-link">

--- a/cms/templates/partials/nav-links/our-work__finance.html
+++ b/cms/templates/partials/nav-links/our-work__finance.html
@@ -1,0 +1,29 @@
+<li>
+    <a href="/increasing-health-and-social-care-worker-flu-vaccinations/"
+    class="menu-link mega-menu-link">
+      Increasing Health and Social Care Worker Flu Vaccinations: Five Components
+    </a>
+</li>
+<li>
+    <a href="/bus-case"
+    class="menu-link mega-menu-link">
+      Business case approval process – Capital Investment, Property, Equipment and Digital Technology
+    </a>
+</li>
+<li>
+    <a href="/pay-syst"
+    class="menu-link mega-menu-link">
+      NHS payment system
+    </a>
+</li>
+<li>
+    <a href="/financial-accounting-and-reporting"
+    class="menu-link mega-menu-link">
+      NHS providers: financial accounting and reporting
+    </a>
+</li>
+
+<li class="mobile-menu-back-item"
+class="menu-link mega-menu-link">
+    <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
+</li>

--- a/cms/templates/partials/navigation.html
+++ b/cms/templates/partials/navigation.html
@@ -47,6 +47,14 @@ CODEPEN: https://codepen.io/vixxofsweden/pen/xxGGYOE
                           Commissioning
                         </a>
                     </li>
+                    <li>
+                        <a href="javascript:void(0);" class="menu-link mega-menu-link" aria-haspopup="true">
+                          Finance
+                        </a>
+                        <ul class="menu menu-list menu-multiColumn">
+                          {% include "partials/nav-links/our-work__finance.html" %}
+                        </ul>
+                    </li>
                     <li class="mobile-menu-back-item"><!-- Mobile back -->
                         <a href="javascript:void(0);" class="menu-link mobile-menu-back-link">Back</a>
                     </li>


### PR DESCRIPTION
Trello card:  https://trello.com/c/qg5wOp6O

This change adds Finance section under 'Our work' navigation item. 

Previously it was a link in the footer known as 'System guidance and processes', but after conversations with the content team it was suggested to rename it to 'Finance' and moved to the main navigation under 'our work' section.

Also we're including links that were part of Information & Data Quality section directly under Finance and would revisit that decision later.

The links in the footer will need to be removed from the wagtail admin level.

Spreadsheet reference: https://docs.google.com/spreadsheets/d/1MV08IllF4jixN4KxD6RQUIqmpgyZpvlo9LCYjWwiNJg/edit?usp=sharing

<img width="1170" alt="Screenshot 2020-12-02 at 12 13 23" src="https://user-images.githubusercontent.com/2632224/100871302-f7617f00-3497-11eb-87f3-8de74f1337a8.png">
