### PR TITLE
Feature/618 larger nhs logo header

### DIFF
--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -7096,3 +7096,7 @@ nav a {
 .nhsuk-promo__img, img {
   max-width: 100%;
   height: auto; }
+
+.nhsuk-header__logo .nhsuk-logo.nhsei-logo {
+  height: 50px;
+  width: 100px; }

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -26,8 +26,9 @@
         crossorigin>
     {# Global stylesheets #}
     {% block headCSS %}
-    <link rel="stylesheet" href="{% static 'css/nhsuk.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'wagtailnhsukfrontend/css/wagtail-nhsuk-frontend.min.css' %}">
+    <link rel="stylesheet" href="{% static 'css/nhsuk.css' %}">
+
     {% endblock %}
 
     {% block extra_css %}
@@ -71,7 +72,7 @@
     {% block breadcrumb %}
         {% breadcrumb %}
     {% endblock %}
-    
+
     {% block main %}
     {% comment %} <div class="nhsuk-width-container {{ containerClasses }}"> {% endcomment %}
     <main class="nhsuk-main-wrapper {{ mainClasses }}" id="maincontent" role="main">

--- a/cms/templates/partials/header-v1.html
+++ b/cms/templates/partials/header-v1.html
@@ -4,7 +4,7 @@
     <div class="nhsuk-header__logo">
       <a class="nhsuk-header__link" href="/" aria-label="NHS England and Improvement homepage">
       <svg
-          class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false"
+          class="nhsuk-logo nhsei-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false"
           viewBox="0 0 40 16">
           <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
           <path class="nhsuk-logo__text"

--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -73,3 +73,8 @@
   max-width: 100%;
   height: auto;
 }
+
+.nhsuk-header__logo .nhsuk-logo.nhsei-logo{
+  height: 50px;
+  width: 100px;
+}


### PR DESCRIPTION
Trello: https://trello.com/c/O7kALSO1

The logo is now larger, close to the size on the nhs.uk website. Also added a custom nhsei class to it so it doesn’t get accidentally overwritten in case of updating any frontend packages.

Changed how stylesheets are loaded, so that custom styles get applied and not re-set to nhsuk defaults

### Before
![Screenshot 2020-12-03 at 11 49 56](https://user-images.githubusercontent.com/2632224/101014523-e5e2aa80-355d-11eb-9ae8-298b1a41f71f.png)

### After
![Screenshot 2020-12-03 at 11 49 47](https://user-images.githubusercontent.com/2632224/101014556-f1ce6c80-355d-11eb-9529-0614216874bf.png)
