### PR TITLE
Fix/615 tweak menu styling

### DIFF
--- a/cms/static/assets/icons/nav-arrow-bottom.svg
+++ b/cms/static/assets/icons/nav-arrow-bottom.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(90 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/cms/static/assets/icons/nav-arrow-left.svg
+++ b/cms/static/assets/icons/nav-arrow-left.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(-180 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/cms/static/assets/icons/nav-arrow-right.svg
+++ b/cms/static/assets/icons/nav-arrow-right.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowRight">
+
+  <title transform="rotate(0 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(0 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowRight" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowRight" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowRight" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/cms/static/assets/icons/nav-arrow-top.svg
+++ b/cms/static/assets/icons/nav-arrow-top.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(-90 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -6787,7 +6787,7 @@ nav a {
     padding-right: 30px; }
     .menu-link[aria-haspopup="true"]:after {
       content: "";
-      background-image: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowRight.svg#accent");
+      background-image: url("../assets/icons/nav-arrow-right.svg#accent");
       background-size: 14px;
       width: 14px;
       height: 14px;
@@ -6822,9 +6822,9 @@ nav a {
   .menu-bar {
     position: relative; }
     .menu-bar > li > [aria-haspopup="true"]:after {
-      background-image: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowBottom.svg#accent"); }
+      background-image: url("../assets/icons/nav-arrow-bottom.svg#accent"); }
     .menu-bar > li > [aria-haspopup="true"]:hover:after {
-      background-image: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowBottom.svg#light"); }
+      background-image: url("../assets/icons/nav-arrow-bottom.svg#light"); }
     .menu-bar > li > [aria-haspopup="true"]:focus ~ ul {
       display: flex;
       transform-origin: top;
@@ -6841,7 +6841,7 @@ nav a {
       .menu-bar > li > [aria-haspopup="true"]:focus:after,
       .menu-bar > li:focus-within > [aria-haspopup="true"]:after,
       .menu-bar > li:hover > a:after {
-        background-image: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowTop.svg#light"); }
+        background-image: url("../assets/icons/nav-arrow-top.svg#light"); }
   .mega-menu {
     position: absolute;
     top: 100%;
@@ -6926,8 +6926,8 @@ nav a {
       max-height: 100vh;
       width: 100%;
       transition: left .3s; }
-      .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] {
-        font-size: 1.2em; }
+      .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul {
+        border-top: 2px solid #005eb8; }
         .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
           padding-left: 40px; }
         .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
@@ -6960,7 +6960,7 @@ nav a {
         content: "";
         width: 14px;
         height: 12px;
-        background-image: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowLeft.svg#default");
+        background-image: url("../assets/icons/nav-arrow-left.svg#default");
         background-size: 14px;
         margin-right: 10px;
         display: inline-block; }

--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -6800,7 +6800,7 @@ nav a {
     color: #005eb8; }
 
 .mega-menu-header {
-  font-size: 1.2em;
+  font-size: 1rem;
   font-weight: bold;
   color: #00519f; }
 
@@ -6926,12 +6926,14 @@ nav a {
       max-height: 100vh;
       width: 100%;
       transition: left .3s; }
-      .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul {
-        border-top: 2px solid #005eb8; }
-        .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
-          padding-left: 40px; }
-        .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
-          padding-left: 80px; }
+      .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] {
+        font-size: 1rem; }
+        .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul {
+          border-top: 2px solid #005eb8; }
+          .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
+            padding-left: 40px; }
+          .menu-bar > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul > li > [aria-haspopup="true"] ~ ul a {
+            padding-left: 80px; }
       .menu-bar > li > [aria-haspopup="true"] ~ ul [aria-haspopup="true"] {
         color: #212b32; }
         .menu-bar > li > [aria-haspopup="true"] ~ ul [aria-haspopup="true"]:after {
@@ -7019,8 +7021,29 @@ nav a {
 .menu-link small {
   color: #212b32; }
 
+.mega_nav a.menu-link {
+  font-size: 1rem; }
+
 .mega_nav > ul > li {
   margin-bottom: 0; }
+  .mega_nav > ul > li > ul > li {
+    margin-bottom: 0;
+    border-bottom: 1px solid #d9e7f4;
+    border-right: 1px solid #d9e7f4;
+    border-left: 2px solid #005eb8; }
+    .mega_nav > ul > li > ul > li:first-child {
+      border-top: 1px solid #d9e7f4; }
+    .mega_nav > ul > li > ul > li:last-child {
+      border-bottom-left-radius: 5px; }
+    .mega_nav > ul > li > ul > li a.menu-link {
+      padding: 10px; }
+    .mega_nav > ul > li > ul > li > ul > li {
+      margin-bottom: 0;
+      border-bottom: 1px solid #d9e7f4;
+      border-right: 1px solid #d9e7f4;
+      border-left: 1px solid #d9e7f4; }
+      .mega_nav > ul > li > ul > li > ul > li:first-child {
+        border-top: 1px solid #d9e7f4; }
 
 .nhsuk-image {
   width: 100%; }
@@ -7085,7 +7108,7 @@ nav a {
         color: #002f5c; }
 
 .nhsuk-breadcrumb {
-  border-top: 2px solid #005eb8; }
+  border-top: 2px solid #d8dde0; }
 
 .nhsie-search-result-item {
   background-color: #ffffff;

--- a/packages/assets/icons/nav-arrow-bottom.svg
+++ b/packages/assets/icons/nav-arrow-bottom.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(90 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/packages/assets/icons/nav-arrow-left.svg
+++ b/packages/assets/icons/nav-arrow-left.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(-180 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/packages/assets/icons/nav-arrow-right.svg
+++ b/packages/assets/icons/nav-arrow-right.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowRight">
+
+  <title transform="rotate(0 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(0 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowRight" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowRight" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowRight" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/packages/assets/icons/nav-arrow-top.svg
+++ b/packages/assets/icons/nav-arrow-top.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <symbol id="arrowBottom">
+
+  <title transform="rotate(90 24 24)" class="" style="">Icon</title>
+  <polygon points="31.028 19.573 19.975 8.52 15.549 12.948 26.6 24 15.549 35.052 19.975 39.479 31.028 28.427 35.455 24 31.028 19.573" transform="rotate(-90 24 24)" class="" style=""/>
+
+    </symbol>
+  </defs>
+    <view id="default" viewBox="0 0 48 48"/>
+    <use data-variant="default" xlink:href="#arrowBottom" x="0" y="0" fill="#000000"/>
+    <view id="accent" viewBox="0 48 48 48"/>
+    <use data-variant="accent" xlink:href="#arrowBottom" x="0" y="48" fill="#005eb8"/>
+    <view id="light" viewBox="0 96 48 48"/>
+    <use data-variant="light" xlink:href="#arrowBottom" x="0" y="96" fill="#ffffff"/>
+</svg>

--- a/packages/custom-styles/_base.scss
+++ b/packages/custom-styles/_base.scss
@@ -57,7 +57,7 @@
 }
 
 .nhsuk-breadcrumb {
-  border-top: 2px solid $color_nhsuk-blue;
+  border-top: 2px solid $color_nhsuk-grey-4;
 }
 
 .nhsie-search-result-item {

--- a/packages/custom-styles/_nav-v1.scss
+++ b/packages/custom-styles/_nav-v1.scss
@@ -14,6 +14,8 @@ $mobile-menu-back-height:           calc(1.4em + 40px);
 $mobile-menu-back-offset:           calc(0px - (1.4em + 40px));
 $menu-mobile-width:                 350px;
 
+$nav-font-size:                     1rem;
+
 // *, *:before, *:after {
 //     -webkit-box-sizing: border-box;
 //     -moz-box-sizing: border-box;
@@ -71,7 +73,7 @@ nav {
 }
 
 .mega-menu-header {
-  font-size: 1.2em;
+  font-size: $nav-font-size;
   //text-transform: uppercase;
   font-weight: bold;
   color: darken($color-accent, 5%);
@@ -93,9 +95,9 @@ nav {
   // Desktop only
 
   .nav {
-    //margin-top: 50px;
+
     background: $color-light;
-    //margin-left: 12em;
+
     > nav {
       max-width: 1200px;
       margin: 0 auto;
@@ -319,8 +321,10 @@ nav {
           // Second level
           > li {
             > [aria-haspopup="true"] {
-              font-size: 1.2em;
+              font-size: $nav-font-size;
+
               ~ ul {
+                border-top: 2px solid $color_nhsuk-blue;
                 a {
                   padding-left: 40px;
                 }
@@ -534,9 +538,41 @@ nav {
 }
 
 // ------------------ overriding NHSUK STYLES
-
 .mega_nav {
+  a.menu-link {
+    font-size: $nav-font-size;
+  }
   > ul > li {
     margin-bottom: 0;
+
+    > ul > li {
+      margin-bottom: 0;
+      border-bottom: 1px solid tint($color-accent, 85%);
+      border-right: 1px solid tint($color-accent, 85%);
+      border-left: 2px solid $color-accent;
+
+      &:first-child {
+        border-top: 1px solid tint($color-accent, 85%);
+      }
+
+      &:last-child {
+        border-bottom-left-radius: 5px;
+      }
+
+      a.menu-link {
+        padding: 10px;
+      }
+
+      > ul > li {
+        margin-bottom: 0;
+        border-bottom: 1px solid tint($color-accent, 85%);
+        border-right: 1px solid tint($color-accent, 85%);
+        border-left: 1px solid tint($color-accent, 85%);
+
+        &:first-child {
+          border-top: 1px solid tint($color-accent, 85%);
+        }
+      }
+    }
   }
 }

--- a/packages/custom-styles/_nav-v1.scss
+++ b/packages/custom-styles/_nav-v1.scss
@@ -54,7 +54,7 @@ nav {
     padding-right: 30px;
     &:after {
       content: "";
-      background-image: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowRight.svg#accent');
+      background-image: url('../assets/icons/nav-arrow-right.svg#accent');
       background-size: 14px;
       width: 14px;
       height: 14px;
@@ -116,11 +116,11 @@ nav {
       > [aria-haspopup="true"] {
         // STYLING: Down arrow on desktop
         &:after {
-            background-image: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowBottom.svg#accent');
+            background-image: url('../assets/icons/nav-arrow-bottom.svg#accent');
         }
         &:hover {
           &:after {
-            background-image: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowBottom.svg#light');
+            background-image: url('../assets/icons/nav-arrow-bottom.svg#light');
           }
         }
 
@@ -156,7 +156,7 @@ nav {
         background: $color-accent;
         color: $color-light;
         &:after {
-          background-image: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowTop.svg#light');
+          background-image: url('../assets/icons/nav-arrow-top.svg#light');
         }
       }
     }
@@ -376,7 +376,7 @@ nav {
         content: "";
         width: 14px;
         height: 12px;
-        background-image: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/1397521/arrowLeft.svg#default');
+        background-image: url('../assets/icons/nav-arrow-left.svg#default');
         background-size: 14px;
         margin-right: 10px;
         display: inline-block;


### PR DESCRIPTION
Trello card: https://trello.com/c/Q81hKUn4

Changes:
- Added nav icon arrows to be in the assets. We don’t want to rely on using icons hosted by someone else.
- Reduced the padding of the nav links and decreased the font size. (Seems a bit too small, but let's see it with the testing)
- Added light borders to distinguish the menu from the page background
- made the breadcumbs border more subtle so it doesn't interfere visually with the banner and the menu

### Before
![Screenshot 2020-12-03 at 18 09 36](https://user-images.githubusercontent.com/2632224/101070078-c5811300-3592-11eb-951d-7ea51ca9dd23.png)


### After
![Screenshot 2020-12-03 at 18 07 53](https://user-images.githubusercontent.com/2632224/101069920-91a5ed80-3592-11eb-8e82-69d49d9ce28e.png)
![Screenshot 2020-12-03 at 18 08 00](https://user-images.githubusercontent.com/2632224/101069928-92d71a80-3592-11eb-91ea-dc97cf8bcab5.png)
