### PR TITLE
Change copy in the alert banner matching nhs england

### DIFF
--- a/importer/management/commands/make_alert_banner.py
+++ b/importer/management/commands/make_alert_banner.py
@@ -8,7 +8,7 @@ from cms.core.models import CoreSettings
 
 class Command(BaseCommand):
     help = 'Creates the alert banner'
-    
+
     def handle(self, *args, **options):
         settings = CoreSettings.objects.all().first()
         # delete first
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
         settings.alert_banner = """
             <h2>Coronavirus (COVID-19)</h2>
-            <p><a href="https://www.nhs.uk/conditions/coronavirus-covid-19/">Get the latest advice about coronavirus</a></p>
+            <p><a href="http://www.england.nhs.uk/coronavirus/">Our advice for clinicians on the coronavirus is here.</a><br />If you are a member of the public looking for health advice, go to the <a href="https://www.nhs.uk/conditions/coronavirus-covid-19/">NHS website</a>. And if you are looking for the latest travel information, and advice about the government response to the outbreak, go to the <a href="https://www.gov.uk/guidance/wuhan-novel-coronavirus-information-for-the-public">gov.uk website</a>.</p>
         """
         settings.is_visible = True
         settings.save()


### PR DESCRIPTION
Trello: https://trello.com/c/qV8UrNC9

Updated the content in the script creating the alert banner, so that it matches the live NHS England site.

There will be a follow up work required to make the banner editable from the admin menu.

### Before
![Screenshot 2020-12-03 at 18 35 10](https://user-images.githubusercontent.com/2632224/101073023-c2882180-3596-11eb-950e-d088138eb636.png)

### After
![Screenshot 2020-12-03 at 18 35 01](https://user-images.githubusercontent.com/2632224/101073048-cd42b680-3596-11eb-94df-a551e205658d.png)
