### PR TITLE
Remove the sidebar with topic filtering from the news page

### DIFF
--- a/cms/posts/templates/posts/post_index_page.html
+++ b/cms/posts/templates/posts/post_index_page.html
@@ -11,12 +11,6 @@
 
     <div class="nhsuk-grid-row">
 
-        <div class="nhsuk-grid-column-one-third">
-
-            {% include 'includes/side_bar_list.html' with items=categories side_bar_title='Topics' filter='category' %}
-
-        </div>
-
         <div class="nhsuk-grid-column-two-thirds">
 
             <ul class="nhsuk-list nhsuk-list--border">


### PR DESCRIPTION
Trello: https://trello.com/c/XMrRDP1h

Removes the list of topics from the news landing page

I think the landing page should have 'news' somwhere in the main heading, but we will be workin on condensing all news from subsites into one later, so we can address this then.

### Before and after

![Screenshot 2020-12-04 at 16 06 50](https://user-images.githubusercontent.com/2632224/101186404-f3299300-364a-11eb-841f-547cec515a64.png)

![Screenshot 2020-12-04 at 16 07 01](https://user-images.githubusercontent.com/2632224/101186407-f45ac000-364a-11eb-8f31-ba0d72440ac9.png)
