### PR TITLE
WIP Add conent type tag to search results

### DIFF
--- a/cms/search/templates/search/search.html
+++ b/cms/search/templates/search/search.html
@@ -107,12 +107,14 @@
                 <ul class="nhsuk-list nhsuk-list--border">
                     {% for result in search_results %}
                     <li class="nhsuk-panel nhsei-panel-search-result">
+                        <span class="nhsuk-tag nhsuk-tag--grey">Content type</span>
                         <h2 class="nhsuk-u-margin-bottom-1 nhsuk-heading-s">
                             <a href="{% pageurl result %}">{{ result.title|truncatewords:"16" }}</a></h2>
                         <div class="nhsuk-body-s">
                             {{ result.specific.body|truncatewords_html:"20"|richtext|striptags }}
                         </div>
                         <div class="nhsuk-body-s">
+
                             Published: {{ result.first_published_at|date:'d F Y' }} - <em>Latest version
                                 {{ result.latest_revision_created_at|date:'d F Y' }}</em><br>
                         </div>

--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -6709,6 +6709,12 @@ b {
     .nhsuk-list .nhsuk-panel.nhsei-panel-search-result {
       padding: 24px; } }
 
+.nhsei-panel-search-result .nhsuk-tag {
+  margin-bottom: 8px; }
+  @media (min-width: 40.0625em) {
+    .nhsei-panel-search-result .nhsuk-tag {
+      margin-bottom: 8px; } }
+
 .block-panel .nhsuk-panel {
   margin: 0;
   padding: 0;

--- a/packages/custom-styles/_search-results.scss
+++ b/packages/custom-styles/_search-results.scss
@@ -21,3 +21,9 @@
     @include nhsuk-responsive-padding(4);
   }
 }
+
+.nhsei-panel-search-result {
+  .nhsuk-tag {
+    @include nhsuk-responsive-margin(2, 'bottom');
+  }
+}


### PR DESCRIPTION
Add a content type label tag to the search results.

WIP, added the label to the results.

Tried to figure out how to fetch the content type from the Model to show in the tag, but didn't know how.

I think this is ok now to pick up by Nick and add it as a new commit.

![Screenshot 2020-12-04 at 19 11 06](https://user-images.githubusercontent.com/2632224/101204797-b4a0d200-3664-11eb-8509-21d9b854c9a1.png)
