### PR TITLE
configure site to use Elasticsearch 7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,15 @@ POSTGRES_USER=nhsei
 POSTGRES_PASSWORD=secret
 
 DATABASE_URL=psql://nhsei:secret@db/nhsei
+# Elasticsearch
+#------------------------------------------------------------------------------
+ES_JAVA_OPTS=-Xms1g -Xmx1g
+discovery.type=single-node
+xpack.security.enabled=false
+
+# Elasticsearch
+#------------------------------------------------------------------------------
+ES_JAVA_OPTS=-Xms1g -Xmx1g
+discovery.type=single-node
+xpack.security.enabled=false
+

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -73,5 +73,6 @@ jobs:
             --set-string environment.server_email="${{ secrets.SERVER_EMAIL }}" \
             --set-string environment.azure_container="website-media" \
             --set-string environment.azure_connection_string="${{ secrets.AZURE_CONNECTION_STRING }}" \
+            --set-string environment.wagtailsearch_urls="${{ secrets.WAGAILSEARCH_URLS }}" \
             --set-string auth.secret=basic-auth \
             --set-string auth.realm="Authentication required"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -73,6 +73,6 @@ jobs:
             --set-string environment.server_email="${{ secrets.SERVER_EMAIL }}" \
             --set-string environment.azure_container="website-media" \
             --set-string environment.azure_connection_string="${{ secrets.AZURE_CONNECTION_STRING }}" \
-            --set-string environment.wagtailsearch_urls="${{ secrets.WAGAILSEARCH_URLS }}" \
+            --set-string environment.wagtailsearch_urls="${{ secrets.WAGTAILSEARCH_URLS }}" \
             --set-string auth.secret=basic-auth \
             --set-string auth.realm="Authentication required"

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -34,18 +34,17 @@ BASE_DIR = PROJECT_DIR.parent
 INSTALLED_APPS = [
     "cms.home",
     "cms.search",
-    'cms.categories',
-    'cms.posts',
-    'cms.blogs',
-    'cms.pages',
-    'cms.publications',
-    'cms.atlascasestudies',
-    'cms.core',
-
+    "cms.categories",
+    "cms.posts",
+    "cms.blogs",
+    "cms.pages",
+    "cms.publications",
+    "cms.atlascasestudies",
+    "cms.core",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
     "wagtail.contrib.settings",
-    'wagtail.contrib.modeladmin',
+    "wagtail.contrib.modeladmin",
     "wagtail.embeds",
     "wagtail.sites",
     "wagtail.users",
@@ -55,7 +54,6 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.core",
-
     "modelcluster",
     "taggit",
     "django.contrib.admin",
@@ -66,9 +64,8 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "wagtailnhsukfrontend",
     "wagtailnhsukfrontend.settings",
-
     # importer
-    'importer',
+    "importer",
 ]
 
 MIDDLEWARE = [
@@ -152,6 +149,15 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+WAGTAILSEARCH_BACKENDS = {
+    "default": {
+        "BACKEND": "wagtail.search.backends.elasticsearch7",
+        "TIMEOUT": 5,
+        "AUTO_UPDATE": True,
+        "URLS": env.list("WAGTAILSEARCH_URLS", default=["http://search:9200"]),
+    },
+}
 
 
 # Media files (User uploaded images and documents)

--- a/deployment/helm/nhsei-website/templates/deployment.yaml
+++ b/deployment/helm/nhsei-website/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
               value: "{{ .Values.environment.default_from_email }}"
             - name: SERVER_EMAIL
               value: "{{ .Values.environment.server_email }}"
-            - name: WAGAILSEARCH_URLS
+            - name: WAGTAILSEARCH_URLS
               value: "{{ .Values.environment.wagtailsearch_urls }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deployment/helm/nhsei-website/templates/deployment.yaml
+++ b/deployment/helm/nhsei-website/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
               value: "{{ .Values.environment.default_from_email }}"
             - name: SERVER_EMAIL
               value: "{{ .Values.environment.server_email }}"
+            - name: WAGAILSEARCH_URLS
+              value: "{{ .Values.environment.wagtailsearch_urls }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/nhsei-website/values.yaml
+++ b/deployment/helm/nhsei-website/values.yaml
@@ -57,6 +57,7 @@ environment:
   email_url: ""
   server_email: ""
   default_from_email: ""
+  wagtailsearch_urls: ""
 
 ingress:
   enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,13 @@ services:
       - ./:/app:cached
     depends_on:
       - db
-      #- search
+      - search
     ports:
       - "8000:8000"
+    env_file: ./.env
+  search:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     env_file: ./.env
   db:
     image: postgres:11 # match Azure version
     env_file: ./.env
-  #search:
-  #image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
-  #ports:
-  #- "9200"
-  #env_file: ./.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2==2.8.6
 whitenoise[brotli]==5.2.0
 django-storages[azure]==1.10.1
 wagtail-nhsuk-frontend==0.4.4
+elasticsearch==7.10.0


### PR DESCRIPTION
- add config to deployment

To test:
the docker compose file has been updated to include the right version of Elasticsearch, with the default settings you should be able to run the `./manage.py update_index` command and get search results when searching on the site.

Note:
for developers NOT using Docker, to have a working search you will need to do one of the following:

1) configure Elasticsearch 7 to run locally and add the URL for it to your local .env file
2) in you `cms/settings/local.py` add this snippet:

```
WAGTAILSEARCH_BACKENDS = {
    'default': {
        'BACKEND': 'wagtail.search.backends.db',
    }
}
```