### PR TITLE
Remove author reference, change publication time

### DIFF
--- a/cms/blogs/templates/blogs/blog.html
+++ b/cms/blogs/templates/blogs/blog.html
@@ -15,10 +15,13 @@
         {% endif %}
 
         <div class="nhsuk-body-s">
-            <b>Published: </b>{{ self.first_published_at|date:'j N Y | g:m:s a' }} <br> <em>Latest version
-                {{ self.last_published_at|date:'j N Y | g:m:s a' }}</em> | <i>Author: {{ self.author }} we are missing
+            <b>Published: </b>{{ self.first_published_at|date:'d M Y g:i a' }} <br> <em>Latest version
+                {{ self.last_published_at|date:'d M Y g:i a' }}</em>
+              {% comment %}
+                <i>Author: {{ self.author }} we are missing
                 the ability to match ID to
                 a name</i>
+              {% endcomment %}
         </div>
 
         <h1>{{ self.title }}</h1>

--- a/cms/blogs/templates/blogs/blog_index_page.html
+++ b/cms/blogs/templates/blogs/blog_index_page.html
@@ -31,10 +31,14 @@
                         {{ blog.body|truncatewords_html:"40"|striptags|safe }}
                     </div>
                     <p class="nhsuk-body-s">
-                        <b>Published: </b> {{ blog.first_published_at|date:'j N Y | g:m:s a' }} - <em>Latest version
-                            {{ blog.last_published_at|date:'j N Y | g:m:s a' }}</em><br>
+                        <b>Published: </b> {{ blog.first_published_at|date:'d M Y g:i a' }} - <em>Latest version
+                            {{ blog.last_published_at|date:'d M Y g:i a' }}</em><br>
+
+                      {% comment %}
                         <b>Author: </b>{{ blog.author }} we are missing the ability to match ID
                         to a name <br>
+                      {% endcomment %}
+                      
                         {% if blog.blog_category_relationship.all %}
                         <b>Topics:</b>
                         {% for category in blog.blog_category_relationship.all %}

--- a/cms/posts/templates/posts/post.html
+++ b/cms/posts/templates/posts/post.html
@@ -18,8 +18,11 @@
         {% endif %}
 
         <div class="nhsuk-body-s">
-            {{ self.first_published_at|date:'j N Y | g:m:s a' }} | Author: {{ self.author }} <i>we are missing the ability to match ID to
+          <b>Published: </b>{{ self.first_published_at|date:'d M Y g:i a' }}
+            {% comment %}
+             | Author: {{ self.author }} <i>we are missing the ability to match ID to
                 a name</i>
+            {% endcomment %}
         </div>
 
         <h1>{{ self.title }}</h1>

--- a/cms/posts/templates/posts/post_index_page.html
+++ b/cms/posts/templates/posts/post_index_page.html
@@ -23,10 +23,12 @@
                         {{ post.body|truncatewords_html:"40"|striptags|safe }}
                     </div>
                     <p class="nhsuk-body-s">
-                        <b>Published: </b> {{ post.first_published_at|date:'j N Y | g:m:s a' }} - <em>Latest version
-                            {{ post.last_published_at|date:'j N Y | g:m:s a' }}</em><br>
+                        <b>Published: </b> {{ post.first_published_at|date:'d M Y g:i a' }} - <em>Latest version
+                            {{ post.last_published_at|date:'d M Y g:i a' }}</em><br>
+                      {% comment %}
                         <b>Author: </b>{{ post.author }} we are missing the ability to match ID
                         to a name <br>
+                      {% endcomment %}
                         {% if post.post_category_relationship.all %}
                         <b>Topics:</b>
                         {% for category in post.post_category_relationship.all %}

--- a/cms/publications/templates/publications/publication.html
+++ b/cms/publications/templates/publications/publication.html
@@ -10,8 +10,8 @@
 
     <div class="nhsuk-review-date">
         <p class="nhsuk-body-s">
-            Page first published: {{ self.first_published_at|date:'j N Y | g:m:s a' }}<br>
-            Last updated: {{ self.last_published_at|date:'j N Y | g:m:s a' }}
+            Page first published: {{ self.first_published_at|date:'d M Y  g:i a' }}<br>
+            Last updated: {{ self.last_published_at|date:'d M Y  g:i a' }}
         </p>
     </div>
     <!-- <div class="nhsuk-body-s">

--- a/cms/publications/templates/publications/publication_index_page.html
+++ b/cms/publications/templates/publications/publication_index_page.html
@@ -16,7 +16,7 @@
             {% include 'includes/side_bar_list.html' with items=publication_types side_bar_title='Publication Type'  filter='publication_type' %}
 
             {% include 'includes/side_bar_list.html' with items=categories side_bar_title='Topics' filter='category' %}
-                
+
     </div>
 
     <div class="nhsuk-grid-column-two-thirds">
@@ -24,7 +24,7 @@
         <ul class="nhsuk-list nhsuk-list--border">
 
             {% for publication in publications %}
-            
+
             <li class="nhsuk-panel">
                 <h2 class="nhsuk-u-margin-bottom-1 nhsuk-heading-s">
                     <a href="{{ publication.url }}">{{ publication.title }}</a>
@@ -33,10 +33,13 @@
                 {{ publication.body|truncatewords_html:"40"|striptags|safe }}
                 </div>
                 <p class="nhsuk-body-s">
-                    <b>Published: </b> {{ publication.first_published_at|date:'j N Y | g:m:s a' }} - <em>Latest version
-                        {{ publication.last_published_at|date:'j N Y | g:m:s a' }}</em><br>
+                    <b>Published: </b> {{ publication.first_published_at|date:'d M Y g:i a' }} - <em>Latest version
+                        {{ publication.last_published_at|date:'d M Y g:i a' }}</em><br>
+
+                  {% comment %}
                     <b>Author: </b>{{ publication.author }} we are missing the ability to match ID
                     to a name <br>
+                  {% endcomment %}
                     {% if publication.publication_publication_type_relationship.all %}
                     <b>Publication Type:</b>
                     {% for publication_type in publication.publication_publication_type_relationship.all %}
@@ -50,7 +53,7 @@
                     {% endfor %}
                     {% endif %}
                 </p>
-            </li>    
+            </li>
 
             {% endfor %}
 


### PR DESCRIPTION
Commented out Authors across the pages in news and blog landing pages and posts.
Removed the seconds from the published and newest version time.