### PR TITLE
Fix/remove topics from blogs and publications

### DIFF
--- a/cms/atlascasestudies/templates/atlascasestudies/atlas_case_study.html
+++ b/cms/atlascasestudies/templates/atlascasestudies/atlas_case_study.html
@@ -25,8 +25,11 @@
         {% endif %}
 
         <div class="nhsuk-body-s">
-            {{ self.first_published_at|date }} | By: {{ self.author }} this content comes from a custom field (coming
+            {{ self.first_published_at|date }}
+            {% comment %}
+             | By: {{ self.author }} this content comes from a custom field (coming
             soon)
+            {% endcomment %}
         </div>
         <h1>{{ self.title }}</h1>
         {{ self.body|richtext }}

--- a/cms/atlascasestudies/templates/atlascasestudies/atlas_case_study_index_page.html
+++ b/cms/atlascasestudies/templates/atlascasestudies/atlas_case_study_index_page.html
@@ -36,8 +36,10 @@
                     <p class="nhsuk-body-s">
                         <b>Published: </b> {{ atlas_case_study.first_published_at|date:'d F Y' }} - <em>Latest version
                             {{ atlas_case_study.last_published_at|date:'d F Y' }}</em><br>
+                      {% comment %}
                         <b>Author: </b>{{ atlas_case_study.author }} we are missing the ability to match ID
                         to a name <br>
+                      {% endcomment %}
                         {% if atlas_case_study.atlas_case_study_category_relationship.all %}
                         <b>Topics:</b>
                         {% for category in atlas_case_study.atlas_case_study_category_relationship.all %}

--- a/cms/blogs/templates/blogs/blog_index_page.html
+++ b/cms/blogs/templates/blogs/blog_index_page.html
@@ -11,15 +11,9 @@
 
     <div class="nhsuk-grid-row">
 
-        <div class="nhsuk-grid-column-one-third">
-
-            {% include 'includes/side_bar_list.html' with items=categories side_bar_title='Topics' filter='category' %}
-
-        </div>
-
         <div class="nhsuk-grid-column-two-thirds">
 
-            <ul class="nhsuk-list nhsuk-list--border">
+            <ul class="nhsuk-list nhsuk-list--border nhsei-landing-panel-list">
 
                 {% for blog in blogs %}
 
@@ -38,7 +32,7 @@
                         <b>Author: </b>{{ blog.author }} we are missing the ability to match ID
                         to a name <br>
                       {% endcomment %}
-                      
+
                         {% if blog.blog_category_relationship.all %}
                         <b>Topics:</b>
                         {% for category in blog.blog_category_relationship.all %}

--- a/cms/publications/templates/publications/publication_index_page.html
+++ b/cms/publications/templates/publications/publication_index_page.html
@@ -15,8 +15,6 @@
 
             {% include 'includes/side_bar_list.html' with items=publication_types side_bar_title='Publication Type'  filter='publication_type' %}
 
-            {% include 'includes/side_bar_list.html' with items=categories side_bar_title='Topics' filter='category' %}
-
     </div>
 
     <div class="nhsuk-grid-column-two-thirds">

--- a/cms/static/css/nhsuk.css
+++ b/cms/static/css/nhsuk.css
@@ -6733,6 +6733,9 @@ b {
   .nhsei-article-list .nhsei-article-list--title {
     margin-bottom: 8px; }
 
+.nhsuk-list.nhsei-landing-panel-list .nhsuk-panel:first-child {
+  margin-top: 0; }
+
 nav ul, nav li {
   list-style: none;
   padding: 0;

--- a/packages/custom-styles/_landing-panel-list.scss
+++ b/packages/custom-styles/_landing-panel-list.scss
@@ -1,0 +1,5 @@
+.nhsuk-list.nhsei-landing-panel-list {
+  .nhsuk-panel:first-child {
+    margin-top: 0;
+  }
+}

--- a/packages/nhsuk.scss
+++ b/packages/nhsuk.scss
@@ -51,6 +51,7 @@
 @import 'custom-styles/wagtail_frontend_temporary_over_rides';
 
 @import 'custom-styles/article-list';
+@import 'custom-styles/blogs-landing';
 
 @import 'custom-styles/nav-v1';
 


### PR DESCRIPTION
Removed the topics.

On the blogs page it caused a lot of space between the first blog article and the header, so added a general class that could handle removing the top margin on the panel from the first child.

There was no ticket for this case, so it was ommitted in the past PR.
It shouldn’t be a part of this branch really, but aren’t we have bigger things to worry about.

### After 
![Screenshot 2020-12-08 at 15 20 11](https://user-images.githubusercontent.com/2632224/101502594-0ac58c00-3969-11eb-9546-2cc5632731c0.png)

![Screenshot_2020-12-08 NHS England Improvement](https://user-images.githubusercontent.com/2632224/101502620-1022d680-3969-11eb-91a6-da65905fe190.png)
