### PR TITLE
Rename guide to section ARIA on side nav

### DIFF
--- a/cms/pages/templates/pages/base_page.html
+++ b/cms/pages/templates/pages/base_page.html
@@ -56,9 +56,8 @@
         </div>
         <div class="nhsuk-grid-column-one-third">
             {% if children %}
-            <h2>In this section</h2>
-            <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
-                <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+            <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this section" aria-labbeledby="sideNav">
+                <h2 id="sideNav" class="nhsuk-heading-s">Pages in this section</h2>
                 <ol class="nhsuk-contents-list__list">
                     {% for child in children %}
                     <li class="nhsuk-contents-list__item">

--- a/cms/pages/templates/pages/components_page.html
+++ b/cms/pages/templates/pages/components_page.html
@@ -7,7 +7,7 @@
 
 <div class="nhsuk-width-container">
     <h1>{{ self.title }}</h1>
-    
+
 
     {% for block in self.body %}
         {% include_block block %}
@@ -56,9 +56,8 @@
     </ul> {% endcomment %}
 
     {% if children %}
-    <h2>In this section</h2>
-    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
-        <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this section" aria-labbeledby="sideNav">
+        <h2 id="sideNav" class="nhsuk-heading-s">Pages in this section</h2>
         <ol class="nhsuk-contents-list__list">
             {% for child in children %}
             <li class="nhsuk-contents-list__item">

--- a/cms/pages/templates/pages/landing_page.html
+++ b/cms/pages/templates/pages/landing_page.html
@@ -8,8 +8,8 @@
 <div class="nhsuk-width-container">
     <h1>{{ self.title }}</h1>
     {% if children %}
-    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this guide">
-        <h2 class="nhsuk-u-visually-hidden">Contents</h2>
+    <nav class="nhsuk-contents-list" role="navigation" aria-label="Pages in this section" aria-labbeledby="sideNav">
+        <h2 id="sideNav" class="nhsuk-heading-s">Pages in this section</h2>
         <ol class="nhsuk-contents-list__list">
             {% for child in children %}
             <li class="nhsuk-contents-list__item">


### PR DESCRIPTION
Improving ARIA of the side navigation.
Added '`aria-labelledby`' to the nav with the H2 reference. 
Renamed the heading to _Pages in this section_ and made visibe.
Removed the top heading duplicate.

Now the structure follows the guidance:
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html

Before - the problem:
The ‘guide’ name refers to the example from ‘Mini Hub’ nhs.uk design pattern.
The ‘contents’ component needs an ARIA name that is more contextual.

Left ‘as is’ the ‘cms/core/templates/blocks/jump_menu_block.html’ as I’m not sure how and where it is used.

### Before and after

#### Sidebar navigation
![Screenshot 2020-12-08 at 18 15 39](https://user-images.githubusercontent.com/2632224/101524438-d4483b00-3981-11eb-990a-5ec833d7e779.png) 

![Screenshot 2020-12-08 at 18 15 29](https://user-images.githubusercontent.com/2632224/101524434-d3170e00-3981-11eb-9e36-a482ba195fc4.png)

#### Landing and components page children navigation
![Screenshot 2020-12-08 at 18 16 20](https://user-images.githubusercontent.com/2632224/101524607-11acc880-3982-11eb-8f90-e97f866302c7.png)
![Screenshot 2020-12-08 at 18 16 27](https://user-images.githubusercontent.com/2632224/101524609-11acc880-3982-11eb-8b2a-d319eed8b53b.png)
