### PR TITLE
Feature/add logging config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - documentation folder /docs and moved importer docs there
 - requirements.dev to assist with installing dependencies for virtual environments
 - Add dependabot.yml file
+- Add logging config to cms/settings/base.py
 
 ### Changed
 - cms/settings/dev.py to serve local static assets

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -199,3 +199,49 @@ SERVER_EMAIL = env("SERVER_EMAIL", default="root@localhost")
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="root@localhost")
 
 vars().update(EMAIL_CONFIG)
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"},
+    },
+    "formatters": {
+        "simple": {"format": "%(levelname)s %(message)s"},
+        "general": {
+            "format": (
+                "%(process)-5d %(thread)d %(name)-50s %(levelname)-8s " "- %(message)s"
+            ),
+        },
+    },
+    "handlers": {
+        "mail_admins": {
+            "level": "ERROR",
+            "class": "django.utils.log.AdminEmailHandler",
+            "filters": ["require_debug_false"],
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "general",
+            "filters": ["require_debug_true"],
+        },
+        "console_debug_false": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["mail_admins", "console_debug_false"],
+        },
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": True,
+        },
+        "cms": {"handlers": ["console"], "level": "DEBUG"},
+    },
+}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR
- added logging configuration to base settings to output errors via console and send email alerts to ADMINS (when set).

## Screenshots of UI changes
not applicable

## Next steps
- add a support address to the settings https://docs.djangoproject.com/en/3.1/ref/settings/#admins (if email alerts from the site are suitable for the support team). 
