### PR TITLE
Fix/staticfiles manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - requirements.dev to assist with installing dependencies for virtual environments
 - Add dependabot.yml file
 - Add logging config to cms/settings/base.py
+- Specify the Django settings module to use within the Dockerfile for collectstatic
 
 ### Changed
 - cms/settings/dev.py to serve local static assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8000
 # 2. Set PORT variable that is used by Gunicorn. This should match "EXPOSE"
 #    command.
 ENV PYTHONUNBUFFERED=1 \
+    DJANGO_SETTINGS_MODULE=cms.settings.base \
     PORT=8000
 
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR
- specify the Django settings module to use in the Dockerfile. This should ensure that the staticfiles storage used is the same as that in production.

## Screenshots of UI changes
Not applicable

