### PR TITLE
update ingress to create separate secrets for each tls hostname

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -63,8 +63,7 @@ jobs:
             --set-string imageCredentials.registry=${{ secrets.ACR_URL }} \
             --set-string imageCredentials.username=${{ secrets.AZURE_CLIENTID }} \
             --set-string imageCredentials.password=${{ secrets.AZURE_SECRET }} \
-            --set ingress.tls[0].hosts="{${HOSTNAMES}}" \
-            --set ingress.tls[0].secretName="tls-secret" \
+            --set ingress.tlshosts="{${HOSTNAMES}}" \
             --set ingress.hostnames="{${HOSTNAMES}}" \
             --set-string environment.allowed_hosts="${ALLOWED_HOSTS}" \
             --set-string environment.database_url="${{ secrets.DATABASE_URL }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+2021-02-05
+### Changed
+- updated ingress template to use separate secrets for each tls hostname
+
 2021-02-04
 ### Added
 - docs/application.md

--- a/deployment/helm/nhsei-website/templates/ingress.yaml
+++ b/deployment/helm/nhsei-website/templates/ingress.yaml
@@ -21,14 +21,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.auth.realm }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tlshosts }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.ingress.tlshosts }}
     - hosts:
-        {{- range .hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
+      secretName: tls-secret-{{ . | replace "." "_" }}
     {{- end }}
   {{- end }}
   rules:

--- a/deployment/helm/nhsei-website/values.yaml
+++ b/deployment/helm/nhsei-website/values.yaml
@@ -73,10 +73,8 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt
   #hostnames:
   #- www.england.nhs.uk
-  #tls:
-  #- secretName: tls-secret
-  #hosts:
-  #- load_balancer_url
+  #tlshosts:
+  #- staging.england.nhs.uk
 
 resources:
   {}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR
- update the ingress template in the Helm chart + the GitHub action for deployment
This should create a separate tls-secret for each of the tls hostnames, hopefully reducing issues where auth fails for one of the tls hostnames (basic auth, dns issue, etc) and other hostnames on the same secret can no longer load.

## Screenshots of UI changes
not applicable

## Next steps

